### PR TITLE
Export interface as default

### DIFF
--- a/src/cssModuleToInterface.js
+++ b/src/cssModuleToInterface.js
@@ -95,5 +95,7 @@ ${interfaceProperties}
 }
 
 export const locals: ${interfaceName};
+
+export default locals;
 `);
 };


### PR DESCRIPTION
When `namedExport` is set to `false`, the default export type should be exported as default

This lets us import css files with 
```js
import styles from './styles.css'
``` 
instead of 
```js
import * as styles from './styles.css'
```